### PR TITLE
Support passing full `requirements.txt` to the `packages` option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.3.0 | In development
+
+- The `packages` option now accepts the full contents of a `requirements.txt` file.
+  Previously, the contents needed to be converted into a space-separated list (`.replace("\n", " ")`) and stripped of comments and markers.
+
 ## v1.2.1 | 2021-02-15
 
 - Fixed data and scripts not being installed with certain packages (e.g. `nbconvert>=6.0`)

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 - The `packages` option now accepts the full contents of a `requirements.txt` file.
   Previously, the contents needed to be converted into a space-separated list (`.replace("\n", " ")`) and stripped of comments and markers.
+- CMake will now automatically call `find_package(Python)` and ensure that the embedded distribution is found instead of a system-installed Python.
+  Previously, consumer projects needed to do this manually.
 
 ## v1.2.1 | 2021-02-15
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -13,7 +13,7 @@ class EmbeddedPython(ConanFile):
     settings = {"os": ["Windows"]}
     options = {"version": "ANY", "packages": "ANY"}
     default_options = "packages=None"
-    exports = "embedded_python_tools.py"
+    exports = "embedded_python_tools.py", "embedded_python.cmake"
     short_paths = True  # some of the pip packages go over the 260 char path limit on Windows
 
     @property
@@ -123,8 +123,11 @@ class EmbeddedPython(ConanFile):
     def package(self):
         self.copy("embedded_python/*", keep_path=True)
         self.copy("embedded_python_tools.py")
+        self.copy("embedded_python.cmake")
         self.copy("embedded_python/LICENSE.txt", dst="licenses", keep_path=False)
         self.copy("package_licenses.txt", dst="licenses")
 
     def package_info(self):
         self.env_info.PYTHONPATH.append(self.package_folder)
+        self.cpp_info.build_modules = ["embedded_python.cmake"]
+        self.user_info.pyversion = self._pyversion

--- a/embedded_python.cmake
+++ b/embedded_python.cmake
@@ -1,0 +1,2 @@
+set(Python_ROOT_DIR "${CONAN_EMBEDDED_PYTHON_ROOT}/embedded_python")
+find_package(Python COMPONENTS Interpreter Development REQUIRED)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.18)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(KEEP_RPATHS)
+
+if(NOT Python_VERSION VERSION_EQUAL CONAN_USER_EMBEDDED_PYTHON_pyversion)
+    message(FATAL_ERROR "Failed to find the correct Python version")
+endif()

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -7,7 +7,7 @@ project_root = pathlib.Path(__file__).parent
 
 def _read_env(name):
     with open(project_root / f"envs/{name}.txt") as f:
-        return f.read().replace("\n", " ")
+        return f.read()
 
 
 class TestEmbeddedPython(ConanFile):

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -35,12 +35,16 @@ class TestEmbeddedPython(ConanFile):
         if self.options.env:
             script += f"import {name}; print('Found {name}');"
 
-        self.run(f".\\bin\\python\\python.exe -c \"{script}\"")
+        python_exe = str(pathlib.Path("./bin/python/python").resolve())
+        self.run([python_exe, "-c", script])
 
         if self.options.env:
             test_path = project_root / f"envs/{name}_test.py"
-            if test_path.exists():
-                self.run(f".\\bin\\python\\python.exe \"{test_path}\"") 
+        else:
+            test_path = project_root / "envs/baseline_test.py"
+
+        if test_path.exists():
+            self.run([python_exe, str(test_path)]) 
 
     def _test_licenses(self):
         """Ensure that the licenses have been gathered"""

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,6 +1,6 @@
 import pathlib
 import sys
-from conans import ConanFile
+from conans import ConanFile, CMake
 
 project_root = pathlib.Path(__file__).parent
 
@@ -13,6 +13,7 @@ def _read_env(name):
 class TestEmbeddedPython(ConanFile):
     name = "test_embedded_python"
     settings = "os"
+    generators = "cmake"
     options = {"env": "ANY"}
     default_options = {
         "env": None,
@@ -27,6 +28,11 @@ class TestEmbeddedPython(ConanFile):
         import embedded_python_tools
         embedded_python_tools.symlink_import(self, dst="bin/python")
         self.copy("licenses/*", dst="licenses", folder=True, ignore_case=True, keep_path=False)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
 
     def _test_env(self):
         """Ensure that Python runs and finds the installed environment"""

--- a/test_package/envs/baseline_test.py
+++ b/test_package/envs/baseline_test.py
@@ -1,0 +1,6 @@
+import sqlite3
+import _ssl
+import _decimal
+import zlib
+
+print("All optional Python features are importable")


### PR DESCRIPTION
So far, `embedded_python:packages` required that the user passes a space-separated list of packages, just like one would to `pip install <packages>`. This PR enables users to pass a full `requirements.txt` file verbatim, similar to `pip install -r <file>`. But note that `embedded_python:packages` expects the contents of a `requirements.txt` file, not the path to the file.

The full `requirements.txt` format supports markers. They allow conditionally depending on packages based on a platform or Python version. For example, the following line in a `requirements.txt` file will only install the dependency on Windows:
```
pywin32==300; sys_platform == "win32"
```
This is a crucial feature to enable multi-platform support.

As a nice extra benefit, this simplifies how we pass the `packages` specification to Conan. We no longer need `.split(“\n”)`. See the test package for example.

This PR makes a couple of robustness improvements along the way. Please review per-commit.