### PR TITLE
Add support for Linux and macOS

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -4,10 +4,11 @@ on: [push]
 
 jobs:
   test_package:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        embedded-py: [3.7.7, 3.8.3]
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        embedded-py: [3.7.7, 3.8.10]
     env:
       create_pck: conan create . lumicks/testing -o embedded_python:version=${{ matrix.embedded-py }}
     steps:
@@ -18,7 +19,7 @@ jobs:
         python-version: 3.7
     - name: Install Conan
       run: | 
-        python -m pip install conan==1.25.2
+        python -m pip install conan==1.36.0
         conan profile new default --detect
     - name: Test baseline
       run: ${{ env.create_pck }}

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## v1.3.0 | In development
+## v1.3.0 | 2021-06-03
 
+- Added support for Linux and macOS with a couple of caveats to be resolved later:
+  * The standard library is not pre-compiled and zipped so it takes up more space than the Windows variant
+  * The environment is not as locked down as the Windows variant: `pip` is still accessible in the final package
 - The `packages` option now accepts the full contents of a `requirements.txt` file.
   Previously, the contents needed to be converted into a space-separated list (`.replace("\n", " ")`) and stripped of comments and markers.
 - CMake will now automatically call `find_package(Python)` and ensure that the embedded distribution is found instead of a system-installed Python.

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -41,7 +41,10 @@ class TestEmbeddedPython(ConanFile):
         if self.options.env:
             script += f"import {name}; print('Found {name}');"
 
-        python_exe = str(pathlib.Path("./bin/python/python").resolve())
+        if self.settings.os == "Windows":
+            python_exe = str(pathlib.Path("./bin/python/python").resolve())
+        else:
+            python_exe = str(pathlib.Path("./bin/python/bin/python3").resolve())
         self.run([python_exe, "-c", script])
 
         if self.options.env:

--- a/test_package/envs/baseline_test.py
+++ b/test_package/envs/baseline_test.py
@@ -1,6 +1,8 @@
+import bz2
+import lzma
+import ssl
 import sqlite3
-import _ssl
-import _decimal
 import zlib
+import _decimal
 
 print("All optional Python features are importable")

--- a/test_package/envs/nbconvert.txt
+++ b/test_package/envs/nbconvert.txt
@@ -22,7 +22,7 @@ pygments==2.7.4
 pyparsing==2.4.7
 pyrsistent==0.17.3
 python-dateutil==2.8.1
-pywin32==300
+pywin32==300; sys_platform == "win32"
 pyzmq==22.0.2
 six==1.15.0
 testpath==0.4.4


### PR DESCRIPTION
This is an MVP implementation of Linux and macOS support. Everything is functional but there are two caveats that should certainly be resolved in future versions:
 * The standard library is not pre-compiled and zipped so it takes up more space than the Windows variant.
 * The environment is not as locked down as the Windows variant: `pip` is still accessible in the final package.

On Windows, we can simply download a pre-build binary embedded package, but on macOS and Linux, we need to build from source and lock down the environment ourselves. This means that the two points above require a bit more effort. We can tackle this later. For now, this implementation is certainly good enough to get going.