### PR TITLE
Fix slow `find_package(Python)` on Windows

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.3.1 | 2021-06-04
+
+- Fixed very slow `find_package(Python)` on Windows
+
 ## v1.3.0 | 2021-06-03
 
 - Added support for Linux and macOS with a couple of caveats to be resolved later:

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ from conans import ConanFile, tools
 
 class EmbeddedPython(ConanFile):
     name = "embedded_python"
-    version = "1.3.0"  # of the Conan package, `options.version` is the Python version
+    version = "1.3.1"  # of the Conan package, `options.version` is the Python version
     description = "Embedded distribution of Python"
     url = "https://www.python.org/"
     license = "PSFL"

--- a/embedded_python.cmake
+++ b/embedded_python.cmake
@@ -1,2 +1,9 @@
+# A hint for `find_package(Python)`
 set(Python_ROOT_DIR "${CONAN_EMBEDDED_PYTHON_ROOT}/embedded_python")
-find_package(Python COMPONENTS Interpreter Development REQUIRED)
+
+if(WIN32) # Extra hint to speed up the find (not needed for correctness)
+    set(Python_EXECUTABLE "${Python_ROOT_DIR}/python.exe")
+endif()
+
+find_package(Python ${CONAN_USER_EMBEDDED_PYTHON_pyversion} EXACT REQUIRED
+             COMPONENTS Interpreter Development)


### PR DESCRIPTION
It seems that, even though we give it an exact `Python_ROOT_DIR`, CMake does still search the system for all other Python versions. In the end, it does correctly select the one in `Python_ROOT_DIR` as we specified but this entire process is very slow: between 20 seconds and a full minute.

The fix is to give CMake more info: tell it which version of Python is at `Python_ROOT_DIR` and request it to be EXACT. This seems to allow it to return immediately without considering others. It brings the time down to ~3 seconds. And if we also tell it the exact location of `Python_EXECUTABLE`, the time is down to ~1 second.