### PR TITLE
Cache the Conan data directory for faster CI

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -1,6 +1,6 @@
 name: test_package
 
-on: [push]
+on: push
 
 jobs:
   test_package:
@@ -10,17 +10,25 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
         embedded-py: [3.7.7, 3.8.10]
     env:
-      create_pck: conan create . lumicks/testing -o embedded_python:version=${{ matrix.embedded-py }}
+      create_pck: conan create . lumicks/testing -o embedded_python:version=${{ matrix.embedded-py }} --build=missing
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Install Conan
       run: | 
         python -m pip install conan==1.36.0
+        conan config set general.revisions_enabled=True
         conan profile new default --detect
+    - name: Conan cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.conan/data
+          C:\.conan
+        key: conan-cache-${{ runner.os }}-py${{ matrix.embedded-py }}-${{ hashFiles('conanfile.py', '**/test_package.yml') }}
     - name: Test baseline
       run: ${{ env.create_pck }}
     - name: Test with pytest env


### PR DESCRIPTION
Enable `actions/cache@v2` to store Conan data so that we can avoid re-building identical packages for every push.

Enabling `general.revisions_enabled=True` for Conan ensures that it will hash the recipe and recognize stale caches following source changes.

The `test_package` itself is never cached by Conan so the tests will always build and run. It's just the long Python compile/pip install that will be skipped if it has not changed from the last cached data.