### PR TITLE
Fix `packages` option breaking on comments in `requirements.txt`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.3.2 | 2021-06-15
+
+- Fixed `packages` option breaking if comments are present in the `requirements.txt` file
+
 ## v1.3.1 | 2021-06-04
 
 - Fixed very slow `find_package(Python)` on Windows

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ from conans import ConanFile, tools
 
 class EmbeddedPython(ConanFile):
     name = "embedded_python"
-    version = "1.3.1"  # of the Conan package, `options.version` is the Python version
+    version = "1.3.2"  # of the Conan package, `options.version` is the Python version
     description = "Embedded distribution of Python"
     url = "https://www.python.org/"
     license = "PSFL"
@@ -67,10 +67,19 @@ class EmbeddedPython(ConanFile):
         The `extra_packages` can be used to add extra packages (as a Python `list`) to be 
         installed in addition to `self.options.packages`.
         """
-        packages_str = str(self.options.packages)
-        is_file = "\n" in packages_str  # requirements.txt as opposed to space-separated list
-        packages_list = packages_str.strip().split("\n" if is_file else " ")
+        def split_lines(string):
+            """`options.packages` may be encoded as tab, newline or space separated
 
+            The `\n` separator doesn't play well with Conan but we need to support 
+            it for backward compatibility.
+            """
+            for separator in ["\t", "\n"]:
+                if separator in string:
+                    return string.split(separator)
+            return string.split(" ")
+
+        packages_str = str(self.options.packages).strip()
+        packages_list = split_lines(packages_str)
         if extra_packages:
             packages_list.extend(extra_packages)
 

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -7,7 +7,7 @@ project_root = pathlib.Path(__file__).parent
 
 def _read_env(name):
     with open(project_root / f"envs/{name}.txt") as f:
-        return f.read()
+        return f.read().replace("\n", "\t")
 
 
 class TestEmbeddedPython(ConanFile):

--- a/test_package/envs/nbconvert.txt
+++ b/test_package/envs/nbconvert.txt
@@ -1,3 +1,4 @@
+# this is a comment
 async-generator==1.10
 attrs==20.3.0
 bleach==3.3.0


### PR DESCRIPTION
Reading in a raw `requirements.txt` file and passing it to the `packages` option would produce an error if that file included comments.

Our `packages` option is of type `ANY` which Conan takes in as any string. The problem is that Conan doesn’t like newline characters in that string (it uses newlines internally for serialization to delimit individual options). Newline separators worked accidentally for us up until now (quirk in the Conan’s (de)serialization logic). But it definitely breaks if a `requirements.txt` file includes comments.

To work around this limitation, we also allow `packages` to be a tab-separated list. This is a bit weird and reading in a `requirements.txt` file requires `.replace(“\n”, “\t”)` as you can see from the test package. But I don’t see a nicer solution and this does certainly work.