### PR TITLE
Add the `xz_utils` build requirement

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.3.3 | 2021-09-30
+
+- Fixed missing `lzma` module on some Linux systems (added `xz_utils` to the list of build requirements)
+
 ## v1.3.2 | 2021-06-15
 
 - Fixed `packages` option breaking if comments are present in the `requirements.txt` file

--- a/conanfile.py
+++ b/conanfile.py
@@ -36,6 +36,7 @@ class EmbeddedPython(ConanFile):
 
         self.build_requires("sqlite3/3.35.5")
         self.build_requires("bzip2/1.0.8")
+        self.build_requires("xz_utils/5.2.5")
 
         # The pre-conan-center-index version of `openssl` was capitalized as `OpenSSL`.
         # Both versions can't live in the same Conan cache so we need this compatibility


### PR DESCRIPTION
To be able to use the `lzma` python package