### PR TITLE
Add options to pin `setuptools`  version used

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.4.1 | 2021-11-05
+
+- The versions of `setuptools` and `wheel` used to build the embedded environment are now user-configurable via the `setuptools_version` and `wheel_version` recipe options
+
 ## v1.4.0 | 2021-10-12
 
 - The versions of `pip` and `pip-licenses` used to build the embedded environment are now user-configurable via the `pip_version` and `pip_licenses_version` recipe options.

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ from conans import ConanFile, tools
 
 class EmbeddedPython(ConanFile):
     name = "embedded_python"
-    version = "1.4.0"  # of the Conan package, `options.version` is the Python version
+    version = "1.4.1"  # of the Conan package, `options.version` is the Python version
     description = "Embedded distribution of Python"
     url = "https://www.python.org/"
     license = "PSFL"
@@ -16,12 +16,14 @@ class EmbeddedPython(ConanFile):
         "packages": "ANY", 
         "pip_version": "ANY",
         "pip_licenses_version": "ANY",
+        "setuptools_version": "ANY",
         "openssl_variant": ["lowercase", "uppercase"]  # see explanation in `build_requirements()`
     }
     default_options = {
         "packages": None,
         "pip_version": "21.2.4",
         "pip_licenses_version": "3.5.3",
+        "setuptools_version": "57.5.0",
         "openssl_variant": "lowercase"
     }
     exports = "embedded_python_tools.py", "embedded_python.cmake"
@@ -126,7 +128,7 @@ class EmbeddedPython(ConanFile):
         self._gather_licenses(bootstrap)
 
         # Some modules always assume that `setuptools` is installed (e.g. pytest)
-        requirements = self.make_requirements_file(extra_packages=["setuptools==53.0.0"])
+        requirements = self.make_requirements_file(extra_packages=[f"setuptools=={self.options.setuptools_version}"])
         options = "--ignore-installed --no-warn-script-location"
         self.run(f'{bootstrap} -m pip install --no-deps --prefix "{prefix}" {options} -r {requirements}')
 
@@ -190,7 +192,12 @@ class WindowsBuildHelper:
         python_exe = build_folder / "bootstrap/python.exe"
         tools.download("https://bootstrap.pypa.io/get-pip.py", filename="get-pip.py")
         self.conanfile.run(f"{python_exe} get-pip.py")
-        self.conanfile.run(f"{python_exe} -m pip install -U pip=={self.conanfile.options.pip_version}")
+
+        specs = [
+            f"pip=={self.conanfile.options.pip_version}",
+            f"setuptools=={self.conanfile.options.setuptools_version}",
+        ]
+        self.conanfile.run(f"{python_exe} -m pip install -U {' '.join(specs)}")
 
         return python_exe
 
@@ -241,7 +248,12 @@ class UnixLikeBuildHelper:
 
         ver = ".".join(self.conanfile.pyversion.split(".")[:2])
         exe = str(dest_dir / f"bin/python{ver}")
-        self.conanfile.run(f"{exe} -m pip install -U pip=={self.conanfile.options.pip_version}")
+
+        specs = [
+            f"pip=={self.conanfile.options.pip_version}",
+            f"setuptools=={self.conanfile.options.setuptools_version}",
+        ]
+        self.conanfile.run(f"{exe} -m pip install -U {' '.join(specs)}")
 
         # Move the license file to match the Windows layout
         lib_dir = dest_dir / "lib"

--- a/conanfile.py
+++ b/conanfile.py
@@ -17,6 +17,7 @@ class EmbeddedPython(ConanFile):
         "pip_version": "ANY",
         "pip_licenses_version": "ANY",
         "setuptools_version": "ANY",
+        "wheel_version": "ANY",
         "openssl_variant": ["lowercase", "uppercase"]  # see explanation in `build_requirements()`
     }
     default_options = {
@@ -24,6 +25,7 @@ class EmbeddedPython(ConanFile):
         "pip_version": "21.2.4",
         "pip_licenses_version": "3.5.3",
         "setuptools_version": "57.5.0",
+        "wheel_version": "0.37.0",
         "openssl_variant": "lowercase"
     }
     exports = "embedded_python_tools.py", "embedded_python.cmake"
@@ -196,6 +198,7 @@ class WindowsBuildHelper:
         specs = [
             f"pip=={self.conanfile.options.pip_version}",
             f"setuptools=={self.conanfile.options.setuptools_version}",
+            f"wheel=={self.conanfile.options.wheel_version}",
         ]
         self.conanfile.run(f"{python_exe} -m pip install -U {' '.join(specs)}")
 
@@ -252,6 +255,7 @@ class UnixLikeBuildHelper:
         specs = [
             f"pip=={self.conanfile.options.pip_version}",
             f"setuptools=={self.conanfile.options.setuptools_version}",
+            f"wheel=={self.conanfile.options.wheel_version}",
         ]
         self.conanfile.run(f"{exe} -m pip install -U {' '.join(specs)}")
 


### PR DESCRIPTION
Some packages rely on older versions of `setuptools` to be built. Using whatever default version we pick up can thus lead to build failures.

We now exposes a `setuptools_version` option to allow users to pin the specific version they need.