### PR TITLE
Work around a build issue with clang 13 and newer

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.4.3 | 2022-01-28
+
+- Worked around a CPython issue that prevented compilation of Python < 3.9.8 with clang 13: https://bugs.python.org/issue45405
+
 ## v1.4.2 | 2021-11-22
 
 - Fixed missing `zlib` module on some Linux systems (added `zlib` to the list of build requirements)

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## v1.4.3 | 2022-01-28
 
 - Worked around a CPython issue that prevented compilation of Python < 3.9.8 with clang 13: https://bugs.python.org/issue45405
+- The recipe no longer depends on `compiler.cppstd` and `compiler.libcxx` so C++ settings changes will not cause a package rebuild
 
 ## v1.4.2 | 2021-11-22
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -39,6 +39,12 @@ class EmbeddedPython(ConanFile):
             del self.settings.compiler
             del self.settings.build_type
 
+    def configure(self):
+        """We only use the C compiler so ensure we don't need to rebuild if C++ settings change"""
+        if self.settings.os != "Windows":
+            del self.settings.compiler.cppstd
+            del self.settings.compiler.libcxx
+
     def build_requirements(self):
         """On Windows, we download a binary so we don't need anything else"""
         if self.settings.os == "Windows":

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,15 +1,17 @@
 import os
 import pathlib
-import shutil
 from conans import ConanFile, tools
 
 
+# noinspection PyUnresolvedReferences
 class EmbeddedPython(ConanFile):
     name = "embedded_python"
     version = "1.4.2"  # of the Conan package, `options.version` is the Python version
-    description = "Embedded distribution of Python"
-    url = "https://www.python.org/"
     license = "PSFL"
+    description = "Embedded distribution of Python"
+    topics = "embedded", "python"
+    homepage = "https://www.python.org/"
+    url = "https://github.com/lumicks/embedded_python"
     settings = "os", "compiler", "build_type", "arch"
     options = {
         "version": "ANY", 

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -10,6 +10,7 @@ def _read_env(name):
         return f.read().replace("\n", "\t")
 
 
+# noinspection PyUnresolvedReferences
 class TestEmbeddedPython(ConanFile):
     name = "test_embedded_python"
     settings = "os"


### PR DESCRIPTION
The issue is that Python < 3.9.8 cannot be built with clang 13. See https://bugs.python.org/issue45405 for the details.  The latest Python versions have fixed this, but we need to patch the older ones to build with clang 13 and newer.

While I was at it, I also fixed up the recipe a bit. Specifically, C++ settings changes will no longer cause a package rebuild. The issue was that, e.g. changing from C++17 to C++20 in your project would cause a rebuild of all dependencies including `embedded_python`. This is correct for C++ dependencies, but CPython is pure C and did not require a useless rebuild. Deleting `compiler.cppstd` and `compiler.libcxx` in the recipe tells Conan to ignore the setting for the this package.