### PR TITLE
Update pip-licenses to 3.5.4

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: 3.9
     - name: Install Conan
       run: | 
-        python -m pip install conan==1.46.2
+        python -m pip install conan==1.48.1
         conan config set general.revisions_enabled=True
         conan profile new default --detect
         conan profile update settings.compiler.cppstd=17 default

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.4.5 | In development
+
+- Fixed license collection failing with some packages on Windows (bumped default `pip-licenses` to v3.5.4 with the bug fix) 
+
 ## v1.4.4 | 2022-03-30
 
 - Fixed build with Python >= 3.9.11 and >= 3.10.3 on Windows (the installer changed)

--- a/conanfile.py
+++ b/conanfile.py
@@ -25,7 +25,7 @@ class EmbeddedPython(ConanFile):
     default_options = {
         "packages": None,
         "pip_version": "21.2.4",
-        "pip_licenses_version": "3.5.3",
+        "pip_licenses_version": "3.5.4",
         "setuptools_version": "57.5.0",
         "wheel_version": "0.37.0",
         "openssl_variant": "lowercase"


### PR DESCRIPTION
This fixes a bug I've run into recently where pip-license tried to open directories as files causing this issue:

```
[2022-05-23T15:12:30.920Z] Traceback (most recent call last):
[2022-05-23T15:12:30.920Z]   File "runpy.py", line 197, in _run_module_as_main
[2022-05-23T15:12:30.920Z]   File "runpy.py", line 87, in _run_code
[2022-05-23T15:12:30.920Z]   File "C:\cache\conan_short\71f2e4\1\bootstrap\lib\site-packages\piplicenses.py", line 905, in <module>
[2022-05-23T15:12:30.920Z]     main()
[2022-05-23T15:12:30.920Z]   File "C:\cache\conan_short\71f2e4\1\bootstrap\lib\site-packages\piplicenses.py", line 893, in main
[2022-05-23T15:12:30.920Z]     output_string = create_output_string(args)
[2022-05-23T15:12:30.920Z]   File "C:\cache\conan_short\71f2e4\1\bootstrap\lib\site-packages\piplicenses.py", line 551, in create_output_string
[2022-05-23T15:12:30.920Z]     table = create_licenses_table(args, output_fields)
[2022-05-23T15:12:30.920Z]   File "C:\cache\conan_short\71f2e4\1\bootstrap\lib\site-packages\piplicenses.py", line 296, in create_licenses_table
[2022-05-23T15:12:30.920Z]     for pkg in get_packages(args):
[2022-05-23T15:12:30.920Z]   File "C:\cache\conan_short\71f2e4\1\bootstrap\lib\site-packages\piplicenses.py", line 258, in get_packages
[2022-05-23T15:12:30.920Z]     pkg_info = get_pkg_info(pkg)
[2022-05-23T15:12:30.920Z]   File "C:\cache\conan_short\71f2e4\1\bootstrap\lib\site-packages\piplicenses.py", line 178, in get_pkg_info
[2022-05-23T15:12:30.920Z]     (license_file, license_text) = get_pkg_included_file(
[2022-05-23T15:12:30.920Z]   File "C:\cache\conan_short\71f2e4\1\bootstrap\lib\site-packages\piplicenses.py", line 171, in get_pkg_included_file
[2022-05-23T15:12:30.920Z]     with open(test_file, encoding='utf-8',
[2022-05-23T15:12:30.920Z] PermissionError: [Errno 13] Permission denied: 'c:\\cache\\conan_short\\71f2e4\\1\\bootstrap\\lib\\site-packages\\soupsieve-2.3.2.post1.dist-info\\license_files'
[2022-05-23T15:12:30.920Z] embedded_python/1.4.3@lumicks/stable: embedded_python/1.4.3@lumicks/stable: ERROR: Package 'd6312550b45e8b523c68cb0fea71ccc2e4e8fa79' build failed
[2022-05-23T15:12:30.920Z] 
[2022-05-23T15:12:30.920Z] embedded_python/1.4.3@lumicks/stable: WARN: Build folder C:\cache\conan_short\71f2e4\1
[2022-05-23T15:12:30.920Z] ERROR: embedded_python/1.4.3@lumicks/stable: Error in build() method, line 139
[2022-05-23T15:12:30.920Z] 	self._gather_licenses(bootstrap)
[2022-05-23T15:12:30.920Z] while calling '_gather_licenses', line 123
[2022-05-23T15:12:30.920Z] 	self.run(f"{bootstrap} -m piplicenses --with-system --from=mixed --format=plain-vertical"
[2022-05-23T15:12:30.920Z] 	ConanException: Error 1 while executing C:\cache\conan_short\71f2e4\1\bootstrap\python.exe -m piplicenses --with-system --from=mixed --format=plain-vertical --with-license-file --no-license-path --output-file=package_licenses.txt
```