### PR TITLE
conan: Migrate to conan v2 tools

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -24,7 +24,7 @@ jobs:
         echo CXX=/usr/bin/clang++ >> $GITHUB_ENV
     - name: Install Conan
       run: | 
-        python -m pip install conan==1.53
+        python -m pip install conan==1.59
         conan config set general.revisions_enabled=True
         conan profile new default --detect
         conan profile update settings.compiler.cppstd=17 default

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## v1.4.6 | In progress
+## v1.5.0 | 2023-02-28
 
 - Fixed symlink re-creation, in case already existing symlink was invalid
+- Updated to conan v2 methods
 
 ## v1.4.5 | 2022-07-15
 

--- a/embedded_python_tools.py
+++ b/embedded_python_tools.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import pathlib
+from conan.tools.files import copy
 
 
 def _symlink_compat(conanfile, src, dst):
@@ -52,7 +53,7 @@ def symlink_import(conanfile, dst="bin/python/interpreter", bin="bin"):
     _symlink_compat(conanfile, src, dst)
 
     bin = pathlib.Path(bin).absolute()
-    conanfile.copy("python*.dll", dst=bin, src="embedded_python", keep_path=False)
-    conanfile.copy("libpython*.so*", dst=bin, src="embedded_python/lib", keep_path=False)
-    conanfile.copy("libpython*.dylib", dst=bin, src="embedded_python/lib", keep_path=False)
-    conanfile.copy("python*.zip", dst=bin, src="embedded_python", keep_path=False)
+    copy(conanfile, "python*.dll", src, bin, keep_path=False)
+    copy(conanfile, "libpython*.so*", src / "lib", bin, keep_path=False)
+    copy(conanfile, "libpython*.dylib", src / "lib", bin, keep_path=False)
+    copy(conanfile, "python*.zip", src, bin, keep_path=False)

--- a/embedded_python_tools.py
+++ b/embedded_python_tools.py
@@ -45,7 +45,7 @@ def symlink_import(conanfile, dst="bin/python/interpreter", bin="bin"):
     if os.path.lexists(dst):
         try:  # to remove any existing junction/symlink
             os.remove(dst)
-        except:  # this seems to be the only way to find out this is not a junction 
+        except:  # this seems to be the only way to find out this is not a junction
             shutil.rmtree(dst)
 
     src = pathlib.Path(conanfile.deps_cpp_info["embedded_python"].rootpath) / "embedded_python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.black]
+line-length = 100
+target-version = ['py39']
+extend-exclude = '''
+(
+  /(
+      \.git
+    | \.github
+  )/
+)
+'''

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,21 +1,10 @@
 cmake_minimum_required(VERSION 3.18)
 project(test_package)
 
-# `cmake` generator
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(KEEP_RPATHS)
-
-if(NOT Python_VERSION VERSION_EQUAL CONAN_USER_EMBEDDED_PYTHON_pyversion)
-    message(FATAL_ERROR "`cmake` failed to find the correct Python version")
-endif()
-
-# `cmake_find_package` generator
-unset(Python_ROOT_DIR)
-unset(Python_VERSION)
 find_package(embedded_python)
 
-if(NOT Python_VERSION VERSION_EQUAL CONAN_USER_EMBEDDED_PYTHON_pyversion)
-    message(FATAL_ERROR "`cmake_find_package` failed to find the correct Python version")
+if(NOT Python_EXECUTABLE MATCHES "embedded_python")
+    message(FATAL_ERROR "`cmake` failed to find the correct Python")
 endif()
 
 add_executable(test_package src/main.cpp)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -27,6 +27,7 @@ class TestEmbeddedPython(ConanFile):
 
     def imports(self):
         import embedded_python_tools
+
         embedded_python_tools.symlink_import(self, dst="bin/python")
         self.copy("licenses/*", dst="licenses", folder=True, ignore_case=True, keep_path=False)
 


### PR DESCRIPTION
Tried to use the new Autotools build tools provided by conan v2 but somehow it never set the proper include directories or the lib directories. Beside that, didn't find any example on conan center index to understand how to use this properly (though it is highly likely that I may have missed some).