### PR TITLE
Fixed build parameters so dependency zlib is used & conan 2.0 reformat

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.5.1 | 2023-03-13
+
+- Fixed bug where embedded_python will only use local `zlib` instead of the `tool_requires` one.
+
 ## v1.5.0 | 2023-02-28
 
 - Fixed symlink re-creation, in case already existing symlink was invalid


### PR DESCRIPTION
After updating to conan 2.0 AutoToolsDeps doesn't add include paths `-I` to `CPPFLAGS` as AutotoolsBuildEnvironment does so when Python was being build and `zlib` was required to unzip packages, it will only look for it in the system folders.

This commit also reformat the recipe so it complies more with Conan 2.0 style