### PR TITLE
Fix hardcoded paths to libpython on macOS builds

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## v1.5.2 | 2023-04-18
 
 - Added a list of all installed packages to `licenses/packages.txt`.
+- Fixed executable's hardcoded search path for `libpython` on macOS.
 
 ## v1.5.1 | 2023-03-13
 


### PR DESCRIPTION
Uses `install_name_tool` to adjust the search path of `libpython` to be relative to the executable.
Adds a test to validate that the path is relative on macOS.