### PR TITLE
conan: Redownload correct python after options change

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,10 @@
+name: Lint
+
+on: push
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: psf/black@stable

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.5.3 | 2023-04-25
+
+- Fixed a bug where the python version would be incorrectly cached between builds as the conan `source` method is only called once.
+
 ## v1.5.2 | 2023-04-18
 
 - Added a list of all installed packages to `licenses/packages.txt`.

--- a/conanfile.py
+++ b/conanfile.py
@@ -88,10 +88,9 @@ class EmbeddedPython(ConanFile):
         """Two-digit integer version, e.g. 3.7.3 -> 37"""
         return "".join(self.pyversion.split(".")[:2])
 
-
     def make_package_list(self):
         """Create a list of package names based on `self.options.packages`
-        
+
         For details of the `self.options.packages` format see `make_requirements_file`
         """
 
@@ -107,8 +106,7 @@ class EmbeddedPython(ConanFile):
             return string.split(" ")
 
         packages_str = str(self.options.packages).strip()
-        return split_lines(packages_str)            
-
+        return split_lines(packages_str)
 
     def make_requirements_file(self, extra_packages=None):
         """Create a `requirements.txt` based on `self.options.packages` and return its path
@@ -154,7 +152,6 @@ class EmbeddedPython(ConanFile):
         package_names = (match.group(1) for match in filter(None, matches))
         with open("packages.txt", "w") as output:
             output.write("\n".join(package_names))
-
 
     def source(self):
         replace_in_file(self, "embedded_python.cmake", "${self.pyversion}", str(self.pyversion))
@@ -303,6 +300,7 @@ class UnixLikeBuildHelper:
 
     def generate(self):
         from conan.tools.gnu import AutotoolsToolchain, AutotoolsDeps
+
         tc = AutotoolsToolchain(self.conanfile, prefix=self.prefix)
         tc.configure_args.extend(["--enable-shared", f"--with-openssl={self._openssl_path}"])
         tc.generate()
@@ -320,21 +318,24 @@ class UnixLikeBuildHelper:
         # the LD_LIBRARY_PATH env variable which is not at all what we want for this self-contained
         # package. Unlike RUNPATH, RPATH takes precedence over LD_LIBRARY_PATH.
         if self.conanfile.settings.os == "Linux":
-            deps.environment.append("LDFLAGS", ["-Wl,-rpath='\$\$ORIGIN/../lib'", "-Wl,--disable-new-dtags"])
+            deps.environment.append(
+                "LDFLAGS", ["-Wl,-rpath='\$\$ORIGIN/../lib'", "-Wl,--disable-new-dtags"]
+            )
 
         deps.generate()
 
     def build(self):
         from conan.tools.gnu import Autotools
+
         autotools = Autotools(self.conanfile)
         autotools.configure()
         autotools.make()
 
     def install(self):
         from conan.tools.gnu import Autotools
+
         autotools = Autotools(self.conanfile)
-        autotools.install(
-            args=["DESTDIR=''"])  # already handled by `prefix=dest_dir`
+        autotools.install(args=["DESTDIR=''"])  # already handled by `prefix=dest_dir`
 
         ver = ".".join(self.conanfile.pyversion.split(".")[:2])
         exe = str(self.prefix / f"bin/python{ver}")
@@ -372,7 +373,7 @@ class UnixLikeBuildHelper:
 
         buffer = StringIO()
         self.conanfile.run(f"otool -L {exe}", output=buffer)
-        lines = buffer.getvalue().strip().split('\n')[1:]
+        lines = buffer.getvalue().strip().split("\n")[1:]
         libraries = [line.split()[0] for line in lines]
 
         prefix = str(self.prefix)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -54,22 +54,20 @@ class TestEmbeddedPython(ConanFile):
         name = str(self.options.env) if self.options.env else "baseline"
         self.run(f"{python_exe} {project_root / name / 'test.py'}", run_environment=True)
 
-
     def _test_libpython_path(self):
         if self.settings.os != "Macos":
             return
 
         python_exe = str(pathlib.Path("./bin/python/bin/python3").resolve())
         buffer = StringIO()
-        self.run(f'otool -L {python_exe}', run_environment=True, output=buffer)
-        lines = buffer.getvalue().strip().split('\n')[1:]
+        self.run(f"otool -L {python_exe}", run_environment=True, output=buffer)
+        lines = buffer.getvalue().strip().split("\n")[1:]
         libraries = [line.split()[0] for line in lines]
         candidates = [lib for lib in libraries if "libpython" in lib]
         assert candidates, f"libpython dependency not found in 'otool' output: {libraries}"
 
         for lib in candidates:
             assert lib.startswith("@executable_path"), f"libpython has an unexpected prefix: {lib}"
-
 
     def _test_embed(self):
         """Ensure that everything is available to compile and link to the embedded Python"""


### PR DESCRIPTION
I should probably add a test to reproduce this. As of now to reproduce this, we need to install 1.5.1/1.5.2 embedded_python with any python version and then reinstall it again with a different minor version. it should build from the previous source.

The problem was the recipe was not redownloading the sources after the change in the python version. The bug became obvious when the minor version changed since the the python executable changes from python39 to python310. Now we just download the sources inside the the generate method which is every time ensuring the correct python version all the time.