### PR TITLE
tools: Use current filepath instead of using deprecated attribute

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.5.4 | 2023-05-02
+
+- Removed the only usage of deprecated attribute `deps_cpp_info` of `Conanfile` from `embedded_python_tools.py`.
+
 ## v1.5.3 | 2023-04-25
 
 - Fixed a bug where the python version would be incorrectly cached between builds as the conan `source` method is only called once.

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,7 +12,7 @@ required_conan_version = ">=1.56.0"
 # noinspection PyUnresolvedReferences
 class EmbeddedPython(ConanFile):
     name = "embedded_python"
-    version = "1.5.3"  # of the Conan package, `options.version` is the Python version
+    version = "1.5.4"  # of the Conan package, `options.version` is the Python version
     license = "PSFL"
     description = "Embedded distribution of Python"
     topics = "embedded", "python"

--- a/embedded_python_tools.py
+++ b/embedded_python_tools.py
@@ -48,8 +48,8 @@ def symlink_import(conanfile, dst="bin/python/interpreter", bin="bin"):
             os.remove(dst)
         except:  # this seems to be the only way to find out this is not a junction
             shutil.rmtree(dst)
-
-    src = pathlib.Path(conanfile.deps_cpp_info["embedded_python"].rootpath) / "embedded_python"
+    root_folder = pathlib.Path(__file__).resolve().parent
+    src = root_folder / "embedded_python"
     _symlink_compat(conanfile, src, dst)
 
     bin = pathlib.Path(bin).absolute()


### PR DESCRIPTION
The attribute `Conanfile::deps_cpp_info` is deprecated in conan2 and the equivalent which is `Conanfile::dependencies` is only available in the `generate` and `validate` methods as of now. But unfortunately the helper script is not available inside those methods. Luckily the location of the script is just beside the package so we can get the location from there