### PR TITLE
Speed up license gathering and futher reduce package size

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.7.0 | In development
+
+- Recipe build performance and Conan cache usage have been improved further (on top of the improvements in v1.6.0) by optimizing the way licenses are gathered. The recipe now takes advantage of a new feature in `pip-license` v4.2.0 to gather licenses from an external environment. This way, we don't need to re-install packages just to gather licenses, thus cutting both build time and Conan cache usage in half.
+
 ## v1.6.0 | 2023-06-07
 
 - Added tests for Python 3.11 and set minimum supported Python version to 3.9.8.

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## v1.7.0 | In development
+## v1.7.0 | 2023-06-22
 
 - Recipe build performance and Conan cache usage have been improved further (on top of the improvements in v1.6.0) by optimizing the way licenses are gathered. The recipe now takes advantage of a new feature in `pip-license` v4.2.0 to gather licenses from an external environment. This way, we don't need to re-install packages just to gather licenses, thus cutting both build time and Conan cache usage in half.
+- Reduced package size for Python >= 3.10 on macOS and Linux by removing the `libpython*.a` static library. This brings these platforms in line with the existing package for Windows. Only shared libraries are included.
 
 ## v1.6.0 | 2023-06-07
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -37,7 +37,7 @@ class EmbeddedPython(ConanFile):
     short_paths = True  # some of the pip packages go over the 260 char path limit on Windows
 
     def requirements(self):
-        self.requires(f"embedded_python-core/1.0.0@{self.user}/{self.channel}")
+        self.requires(f"embedded_python-core/1.1.0@{self.user}/{self.channel}")
 
     def configure(self):
         self.options["embedded_python-core"].version = self.options.version

--- a/core/conanfile.py
+++ b/core/conanfile.py
@@ -12,7 +12,7 @@ required_conan_version = ">=1.59.0"
 # noinspection PyUnresolvedReferences
 class EmbeddedPythonCore(ConanFile):
     name = "embedded_python-core"
-    version = "1.0.0"  # of the Conan package, `options.version` is the Python version
+    version = "1.1.0"  # of the Conan package, `options.version` is the Python version
     license = "PSFL"
     description = "The core embedded Python (no extra pip packages)"
     topics = "embedded", "python"
@@ -107,6 +107,7 @@ class EmbeddedPythonCore(ConanFile):
         openssl_path = self.dependencies[openssl_pck].package_folder
         tc.configure_args += [
             "--enable-shared",
+            "--without-static-libpython",
             "--disable-test-modules",
             f"--with-openssl={openssl_path}",
         ]


### PR DESCRIPTION
This PR builds on https://github.com/lumicks/embedded_python/pull/33. Recipe build speed is ~2x faster and Conan cache usage is reduced to ~0.5x on top of the improvements from 
 https://github.com/lumicks/embedded_python/pull/33.

This mainly comes from changes in license gathering. Originally, `pip-licenses` could only gather licenses from the same environment where it was installed. To avoid mixing `pip-licenses` and its dependencies from the final packaged environment, the recipe would install all packages twice: once in a bootstrap environment in the `build` folder and once again in the final environment in the `package` folder. `pip-licenses` would be in the bootstrap environment.

Since v4.2.0, `pip-licenses` has a `--python` option that allows it to collect licenses from an external environment. That means the recipe no longer needs to install packages twice in different environments, hence the major speedup.