### PR TITLE
Fix runtime conflict between embedded and system Python

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        embedded-py: [3.9.8, 3.11.3]
+        embedded-py: [3.9.8, 3.11.5]
     env:
       create_pck: conan create . lumicks/testing -o embedded_python:version=${{ matrix.embedded-py }} --build=missing
     steps:

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.8.1 | In development
+
+- Fixed Python include dirs being added twice (didn't cause any issues, just noise on the command line).
+
 ## v1.8.0 | 2023-07-12
 
 - Added support for building with `openssl` v3 for Python 3.10 and newer.

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## v1.8.1 | In development
+## v1.8.1 | 2023-10-02
 
+- Fixed packaging and runtime errors caused by conflicts with an incompatible system Python installation or `pip` packages installed in the user's home directory. The embedded Python now always run in isolated mode regardless of command line flags.
 - Fixed packaging error on Windows when the Conan cache path contains spaces.
 - Fixed Python include dirs being added twice (didn't cause any issues, just noise on the command line).
 - Fixed `openssl` v3 mistakenly being enabled for Python 3.10. While 3.10 has preliminary support for `openssl` v3, Python 3.11 is the real minimum requirement for full support.

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 - Fixed packaging error on Windows when the Conan cache path contains spaces.
 - Fixed Python include dirs being added twice (didn't cause any issues, just noise on the command line).
 - Fixed `openssl` v3 mistakenly being enabled for Python 3.10. While 3.10 has preliminary support for `openssl` v3, Python 3.11 is the real minimum requirement for full support.
+- Bumped default `openssl` to 1.1.1w for Python < 3.11 and v3.1.2 for Python >= 3.11.
 
 ## v1.8.0 | 2023-07-12
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 - Fixed packaging error on Windows when the Conan cache path contains spaces.
 - Fixed Python include dirs being added twice (didn't cause any issues, just noise on the command line).
+- Fixed `openssl` v3 mistakenly being enabled for Python 3.10. While 3.10 has preliminary support for `openssl` v3, Python 3.11 is the real minimum requirement for full support.
 
 ## v1.8.0 | 2023-07-12
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## v1.8.1 | In development
 
+- Fixed packaging error on Windows when the Conan cache path contains spaces.
 - Fixed Python include dirs being added twice (didn't cause any issues, just noise on the command line).
 
 ## v1.8.0 | 2023-07-12

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.59.0"
 # noinspection PyUnresolvedReferences
 class EmbeddedPython(ConanFile):
     name = "embedded_python"
-    version = "1.8.0"  # of the Conan package, `options.version` is the Python version
+    version = "1.8.1"  # of the Conan package, `options.version` is the Python version
     license = "PSFL"
     description = "Embedded distribution of Python"
     topics = "embedded", "python"
@@ -38,7 +38,7 @@ class EmbeddedPython(ConanFile):
     exports_sources = "embedded_python.cmake"
 
     def requirements(self):
-        self.requires(f"embedded_python-core/1.2.0@{self.user}/{self.channel}")
+        self.requires(f"embedded_python-core/1.2.1@{self.user}/{self.channel}")
 
     def configure(self):
         self.options["embedded_python-core"].version = self.options.version

--- a/conanfile.py
+++ b/conanfile.py
@@ -200,9 +200,6 @@ class EmbeddedPython(ConanFile):
         self.env_info.PYTHONPATH.append(self.package_folder)
         self.cpp_info.set_property("cmake_build_modules", ["embedded_python.cmake"])
         self.cpp_info.build_modules = ["embedded_python.cmake"]
-        prefix = pathlib.Path(self.package_folder) / "embedded_python"
-        self.cpp_info.includedirs = [str(prefix / "include")]
-        if self.settings.os == "Windows":
-            self.cpp_info.bindirs = [str(prefix)]
-        else:
-            self.cpp_info.libdirs = [str(prefix / "lib")]
+        self.cpp_info.includedirs = []
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/core/conanfile.py
+++ b/core/conanfile.py
@@ -12,7 +12,7 @@ required_conan_version = ">=1.59.0"
 # noinspection PyUnresolvedReferences
 class EmbeddedPythonCore(ConanFile):
     name = "embedded_python-core"
-    version = "1.2.0"  # of the Conan package, `options.version` is the Python version
+    version = "1.2.1"  # of the Conan package, `options.version` is the Python version
     license = "PSFL"
     description = "The core embedded Python (no extra pip packages)"
     topics = "embedded", "python"
@@ -248,7 +248,7 @@ class EmbeddedPythonCore(ConanFile):
             # We also need headers and the `python3.lib` file to link against
             url = f"https://www.python.org/ftp/python/{self.pyversion}/amd64/dev.msi"
             files.download(self, url, filename="tmp\\dev.msi")
-            self.run(f"msiexec.exe /qn /a {self.build_folder}\\tmp\\dev.msi targetdir={dst}")
+            self.run(f'msiexec.exe /qn /a "{self.build_folder}\\tmp\\dev.msi" targetdir="{dst}"')
             files.rmdir(self, "tmp")
             files.rm(self, "dev.msi", dst)
 

--- a/core/conanfile.py
+++ b/core/conanfile.py
@@ -62,13 +62,10 @@ class EmbeddedPythonCore(ConanFile):
             else:
                 self.requires("mpdecimal/2.5.0")
 
-        # `openssl` v3.1.1 is no-go for macOS ARM: https://github.com/openssl/openssl/issues/20753
-        # The fix will be in v3.1.2: https://github.com/openssl/openssl/pull/21261
-        # Go with v3.0.8 until this is resolved.
         if self.pyversion >= scm.Version("3.11.0"):
-            self.requires("openssl/3.0.8")
+            self.requires("openssl/3.1.2")
         else:
-            self.requires("openssl/1.1.1u")
+            self.requires("openssl/1.1.1w")
 
     @property
     def pyversion(self):

--- a/core/conanfile.py
+++ b/core/conanfile.py
@@ -65,7 +65,7 @@ class EmbeddedPythonCore(ConanFile):
         # `openssl` v3.1.1 is no-go for macOS ARM: https://github.com/openssl/openssl/issues/20753
         # The fix will be in v3.1.2: https://github.com/openssl/openssl/pull/21261
         # Go with v3.0.8 until this is resolved.
-        if self.pyversion >= scm.Version("3.10.0"):
+        if self.pyversion >= scm.Version("3.11.0"):
             self.requires("openssl/3.0.8")
         else:
             self.requires("openssl/1.1.1u")

--- a/core/test_package/test.py
+++ b/core/test_package/test.py
@@ -8,3 +8,18 @@ import uuid
 import zlib
 
 print("All optional Python features are importable")
+
+import sys
+import site
+
+if sys.version_info[:2] >= (3, 11):
+    assert sys.flags.isolated == 1
+    assert sys.flags.ignore_environment == 1
+    assert not site.ENABLE_USER_SITE
+
+print("sys.path:")
+for p in sys.path:
+    print("-", p)
+
+# The environment is isolated so only internal paths should be here
+assert all("embedded_python" in p for p in sys.path)

--- a/test_package/baseline/test.py
+++ b/test_package/baseline/test.py
@@ -8,3 +8,18 @@ import uuid
 import zlib
 
 print("All optional Python features are importable")
+
+import sys
+import site
+
+if sys.version_info[:2] >= (3, 11):
+    assert sys.flags.isolated == 1
+    assert sys.flags.ignore_environment == 1
+    assert not site.ENABLE_USER_SITE
+
+print("sys.path:")
+for p in sys.path:
+    print("-", p)
+
+# The environment is isolated so only internal paths should be here
+assert all("embedded_python" in p for p in sys.path)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -20,7 +20,7 @@ class TestEmbeddedPython(ConanFile):
     options = {"env": [None, "ANY"]}
     default_options = {
         "env": None,
-        "embedded_python:version": "3.11.3",
+        "embedded_python:version": "3.11.5",
     }
 
     def configure(self):


### PR DESCRIPTION
This PR primarily fixes an issue where the embedded `python(3)` executable could still pick up some paths from the system Python which resulted in obscure, hard-to-debug issues. It's important to keep in mind that there are two ways to run the embedded Python:
1. From inside an application via the shared library and Python C API.
2. Directly via the `python(3)` executable in the embedded package.

Case 1 is how we mainly use it and it wasn't really an issue because we already enabled isolated mode at initialization time using the [Python C API](https://docs.python.org/3/c-api/init_config.html).

Case 2 is something we do at build time to run some utilities (e.g. convert Jupytext to `. ipynb` files) or at runtime (launch Jupyter notebooks in a standalone process). When calling the `python(3)` exe directly, isolated mode can be set either via the `-I` command line parameter or by adding a `._pth` file next to the executable. It's easy to forget or not know to always add `-I` so it's best for the embedded package itself to have a `._pth` file to avoid issues. See the docstrings for more details.

This PR also fixes #36 and a few other smaller bugs. See the individual commit messages. Thanks to @hrishikeshkelkar for finding both the bug and what causes it.