### PR TITLE
Fix `openssl` and `zlib` compatibility by using version ranges

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## v1.8.2 | In development
+## v1.8.2 | 2023-11-17
 
 - Fixed a packaging error on Linux in case the `bin` directory was not created during build.
+- Fixed `openssl` and `zlib` version compatibility by requiring version ranges instead of exact versions. 
 
 ## v1.8.1 | 2023-10-02
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.8.2 | In development
+
+- Fixed a packaging error on Linux in case the `bin` directory was not created during build.
+
 ## v1.8.1 | 2023-10-02
 
 - Fixed packaging and runtime errors caused by conflicts with an incompatible system Python installation or `pip` packages installed in the user's home directory. The embedded Python now always run in isolated mode regardless of command line flags.

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.59.0"
 # noinspection PyUnresolvedReferences
 class EmbeddedPython(ConanFile):
     name = "embedded_python"
-    version = "1.8.1"  # of the Conan package, `options.version` is the Python version
+    version = "1.8.2"  # of the Conan package, `options.version` is the Python version
     license = "PSFL"
     description = "Embedded distribution of Python"
     topics = "embedded", "python"
@@ -38,7 +38,7 @@ class EmbeddedPython(ConanFile):
     exports_sources = "embedded_python.cmake"
 
     def requirements(self):
-        self.requires(f"embedded_python-core/1.2.1@{self.user}/{self.channel}")
+        self.requires(f"embedded_python-core/1.2.2@{self.user}/{self.channel}")
 
     def configure(self):
         self.options["embedded_python-core"].version = self.options.version

--- a/core/conanfile.py
+++ b/core/conanfile.py
@@ -53,7 +53,7 @@ class EmbeddedPythonCore(ConanFile):
         self.requires("sqlite3/3.42.0")
         self.requires("bzip2/1.0.8")
         self.requires("xz_utils/5.4.2")
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/[>=1.2.11 <2]")
         if self.settings.os == "Linux":
             self.requires("libffi/3.4.4")
             self.requires("libuuid/1.0.3")
@@ -63,7 +63,7 @@ class EmbeddedPythonCore(ConanFile):
                 self.requires("mpdecimal/2.5.0")
 
         if self.pyversion >= scm.Version("3.11.0"):
-            self.requires("openssl/3.1.2")
+            self.requires("openssl/[>=3 <4]")
         else:
             self.requires("openssl/1.1.1w")
 

--- a/core/conanfile.py
+++ b/core/conanfile.py
@@ -12,7 +12,7 @@ required_conan_version = ">=1.59.0"
 # noinspection PyUnresolvedReferences
 class EmbeddedPythonCore(ConanFile):
     name = "embedded_python-core"
-    version = "1.2.1"  # of the Conan package, `options.version` is the Python version
+    version = "1.2.2"  # of the Conan package, `options.version` is the Python version
     license = "PSFL"
     description = "The core embedded Python (no extra pip packages)"
     topics = "embedded", "python"
@@ -279,9 +279,11 @@ class EmbeddedPythonCore(ConanFile):
             with open(prefix / f"python{self.short_pyversion}._pth", "w") as f:
                 f.write("\n".join(paths))
 
+            bin_dir = prefix / "bin"
+            bin_dir.mkdir(parents=True, exist_ok=True)
             py_exe = f"python{self.short_pyversion}"
-            os.symlink(f"../{py_exe}", prefix / f"bin/{py_exe}")
-            os.symlink(f"../{py_exe}", prefix / f"bin/python3")
+            os.symlink(f"../{py_exe}", bin_dir / py_exe)
+            os.symlink(f"../{py_exe}", bin_dir / "python3")
 
     def package(self):
         src = self.build_folder


### PR DESCRIPTION
`openssl` and `zlib` are a frequent source of version conflicts as different direct dependencies can transitively depend on different versions of these common libraries. Luckily, Conan Center has started adopting version ranges to help with this. We can adopt the same practice: https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/dependencies.md#version-ranges
