### PR TITLE
Fix build issues due to IDEs overriding the `Python_EXECUTABLE` path

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.9.1 | In development
+
+- Fixed an issue where calling CMake with `-DPython_EXECUTABLE=<system_python>` created conflicts with the embedded Python (either a loud version error, or silently passing the wrong library paths). Some IDEs would pass this flag implicitly and it would hijack the `find_package(Python)` call used internally by this recipe. Now, we specifically protect against this since there should be no traces of system Python in a project that wishes to embed it.
+
 ## v1.9.0 | 2024-05-03
 
 - Added support for Conan v2.

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## v1.9.1 | In development
+## v1.9.1 | 2024-06-17
 
 - Fixed an issue where calling CMake with `-DPython_EXECUTABLE=<system_python>` created conflicts with the embedded Python (either a loud version error, or silently passing the wrong library paths). Some IDEs would pass this flag implicitly and it would hijack the `find_package(Python)` call used internally by this recipe. Now, we specifically protect against this since there should be no traces of system Python in a project that wishes to embed it.
+- Provided an alternative to `embedded_python_tools.symlink_import()`. For dev builds, it's now possible to point `PyConfig::home` to the contents of `bin/.embedded_python(-core).home` to avoid needing to copy the entire Python environment into the build tree every time the project is reconfigured.
 
 ## v1.9.0 | 2024-05-03
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.59.0"
 # noinspection PyUnresolvedReferences
 class EmbeddedPython(ConanFile):
     name = "embedded_python"
-    version = "1.9.0"  # of the Conan package, `embedded_python-core:version` is the Python version
+    version = "1.9.1"  # of the Conan package, `embedded_python-core:version` is the Python version
     license = "PSFL"
     description = "Embedded distribution of Python"
     topics = "embedded", "python"
@@ -35,7 +35,7 @@ class EmbeddedPython(ConanFile):
     exports_sources = "embedded_python.cmake"
 
     def requirements(self):
-        self.requires(f"embedded_python-core/1.3.0@{self.user}/{self.channel}")
+        self.requires(f"embedded_python-core/1.3.1@{self.user}/{self.channel}")
 
     @property
     def pyversion(self):

--- a/core/conanfile.py
+++ b/core/conanfile.py
@@ -27,7 +27,8 @@ class EmbeddedPythonCore(ConanFile):
     default_options = {
         "zip_stdlib": "stored",
     }
-    exports_sources = "embedded_python_tools.py", "embedded_python-core.cmake"
+    exports_sources = "embedded_python_tools.py", "embedded_python*.cmake"
+    package_type = "shared-library"
 
     def validate(self):
         minimum_python = "3.11.5"
@@ -277,7 +278,7 @@ class EmbeddedPythonCore(ConanFile):
     def package(self):
         src = self.build_folder
         dst = pathlib.Path(self.package_folder, "embedded_python")
-        files.copy(self, "embedded_python-core.cmake", src, dst=self.package_folder)
+        files.copy(self, "embedded_python*.cmake", src, dst=self.package_folder)
         files.copy(self, "embedded_python_tools.py", src, dst=self.package_folder)
         license_folder = pathlib.Path(self.package_folder, "licenses")
 
@@ -321,8 +322,10 @@ class EmbeddedPythonCore(ConanFile):
 
     def package_info(self):
         self.env_info.PYTHONPATH.append(self.package_folder)
-        self.cpp_info.set_property("cmake_build_modules", ["embedded_python-core.cmake"])
-        self.cpp_info.build_modules = ["embedded_python-core.cmake"]
+        self.cpp_info.set_property(
+            "cmake_build_modules", ["embedded_python-core.cmake", "embedded_python-tools.cmake"]
+        )
+        self.cpp_info.build_modules = ["embedded_python-core.cmake", "embedded_python-tools.cmake"]
         prefix = pathlib.Path(self.package_folder) / "embedded_python"
         self.cpp_info.includedirs = [str(prefix / "include")]
         if self.settings.os == "Windows":

--- a/core/conanfile.py
+++ b/core/conanfile.py
@@ -13,7 +13,7 @@ required_conan_version = ">=1.59.0"
 # noinspection PyUnresolvedReferences
 class EmbeddedPythonCore(ConanFile):
     name = "embedded_python-core"
-    version = "1.3.0"  # of the Conan package, `options.version` is the Python version
+    version = "1.3.1"  # of the Conan package, `options.version` is the Python version
     license = "PSFL"
     description = "The core embedded Python (no extra pip packages)"
     topics = "embedded", "python"

--- a/core/embedded_python-core.cmake
+++ b/core/embedded_python-core.cmake
@@ -1,12 +1,16 @@
 include_guard(GLOBAL)
 
-# A hint for `find_package(Python)`
-set(Python_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/embedded_python" CACHE STRING "")
-
-if(WIN32) # Extra hint to speed up the find (not needed for correctness)
-    set(Python_EXECUTABLE "${Python_ROOT_DIR}/python.exe" CACHE STRING "")
+# `find_package(Python)` supports specifying `Python_EXECUTABLE` to short-circuit the search.
+# See: https://cmake.org/cmake/help/latest/module/FindPython.html#artifacts-specification
+# When this variable is specified, all other hints are ignored. Note that we `FORCE` set the
+# variables. Otherwise, the values could be hijacked via earlier `set(CACHE)` calls or via
+# `-D` flags on the command line (some IDEs do this implicitly). For projects that embed
+# Python, it's important that there are no traces of system Python in the build.
+set(Python_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/embedded_python" CACHE STRING "" FORCE)
+if(WIN32)
+    set(Python_EXECUTABLE "${Python_ROOT_DIR}/python.exe" CACHE STRING "" FORCE)
 else()
-    set(Python_EXECUTABLE "${Python_ROOT_DIR}/bin/python3" CACHE STRING "")
+    set(Python_EXECUTABLE "${Python_ROOT_DIR}/python3" CACHE STRING "" FORCE)
 endif()
 
 find_package(Python ${self.pyversion} EXACT REQUIRED GLOBAL COMPONENTS Interpreter Development)

--- a/core/embedded_python-tools.cmake
+++ b/core/embedded_python-tools.cmake
@@ -1,0 +1,15 @@
+include_guard(DIRECTORY)
+
+# For development, we want avoid copying all of Python's `lib` and `site-packages` into our
+# build tree every time we re-configure the project. Instead, we can point `PyConfig::home`
+# to the contents of this file to gain access to all the Python packages.
+# For release/deployment, the entire `Python_ROOT_DIR` should be copied into the app's `bin`
+# folder and `PyConfig::home` should point to that.
+function(embedded_python_generate_home_file filename content)
+    if(DEFINED CMAKE_RUNTIME_OUTPUT_DIRECTORY)
+        set(filename ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${filename})
+    endif()
+    file(GENERATE OUTPUT ${filename} CONTENT "${content}")
+endfunction()
+
+embedded_python_generate_home_file(".embedded_python-core.home" "${Python_ROOT_DIR}")

--- a/core/test_package/conanfile.py
+++ b/core/test_package/conanfile.py
@@ -32,7 +32,14 @@ class TestEmbeddedPythonCore(ConanFile):
 
         embedded_python_tools.symlink_import(self, dst="bin/python")
         cmake = CMake(self)
-        cmake.configure(variables={"EXPECTED_PYTHON_CORE_PATH": self._core_package_path.as_posix()})
+        cmake.configure(
+            variables={
+                # To test that we find the correct prefix for `Python_EXECUTABLE`
+                "EXPECTED_PYTHON_CORE_PATH": self._core_package_path.as_posix(),
+                # We specify the wrong exe here (system Python) to test that we do ignore it
+                "Python_EXECUTABLE": sys.executable,
+            }
+        )
         cmake.build()
 
     @property

--- a/core/test_package/src/main.cpp
+++ b/core/test_package/src/main.cpp
@@ -1,13 +1,29 @@
 #include <Python.h>
 #include <iostream>
+#include <fstream>
 #include <filesystem>
+
+std::string find_python_home(std::filesystem::path bin) {
+    const auto local_home = bin / "python";
+    if (std::filesystem::exists(local_home)) {
+        return local_home.string();
+    }
+
+    auto home_file = bin / ".embedded_python.home";
+    if (!std::filesystem::exists(home_file)) {
+        home_file = bin / ".embedded_python-core.home";
+    }
+    auto stream = std::ifstream(home_file);
+    return std::string(std::istreambuf_iterator<char>(stream),
+                       std::istreambuf_iterator<char>());
+}
 
 int main(int argc, const char* argv[]) {
     auto config = PyConfig{};
     PyConfig_InitIsolatedConfig(&config);
 
     const auto bin = std::filesystem::path(argv[0]).parent_path();
-    const auto python_home = (bin / "python").string();
+    const auto python_home = find_python_home(bin);
     if (auto status = PyConfig_SetBytesString(&config, &config.home, python_home.c_str());
         PyStatus_Exception(status)) {
         PyConfig_Clear(&config);

--- a/embedded_python.cmake
+++ b/embedded_python.cmake
@@ -11,7 +11,7 @@
 # since those are already provided by `core`.
 
 if(WIN32)
-    set(EmbeddedPython_EXECUTABLE "${CMAKE_CURRENT_LIST_DIR}/embedded_python/python.exe")
+    set(EmbeddedPython_EXECUTABLE "${CMAKE_CURRENT_LIST_DIR}/embedded_python/python.exe" CACHE STRING "" FORCE)
 else()
-    set(EmbeddedPython_EXECUTABLE "${CMAKE_CURRENT_LIST_DIR}/embedded_python/bin/python3")
+    set(EmbeddedPython_EXECUTABLE "${CMAKE_CURRENT_LIST_DIR}/embedded_python/python3" CACHE STRING "" FORCE)
 endif()

--- a/embedded_python.cmake
+++ b/embedded_python.cmake
@@ -1,3 +1,5 @@
+include_guard(DIRECTORY)
+
 # There is one important thing we want to achieve with the `embedded_python`/`embedded_python-core`
 # split: we want to avoid recompiling the world when only the Python environment packages change
 # but the version/headers/libs stay the same. To do that we must ensure that everything is built
@@ -9,9 +11,13 @@
 # library. On top of that, `embedded_python.cmake` adds `EmbeddedPython_EXECUTABLE` which is aware
 # of the full environment with `pip` packages. Note that we do no provide any include or lib dirs
 # since those are already provided by `core`.
-
+set(EmbeddedPython_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/embedded_python" CACHE STRING "" FORCE)
 if(WIN32)
-    set(EmbeddedPython_EXECUTABLE "${CMAKE_CURRENT_LIST_DIR}/embedded_python/python.exe" CACHE STRING "" FORCE)
+    set(EmbeddedPython_EXECUTABLE "${EmbeddedPython_ROOT_DIR}/python.exe" CACHE STRING "" FORCE)
 else()
-    set(EmbeddedPython_EXECUTABLE "${CMAKE_CURRENT_LIST_DIR}/embedded_python/python3" CACHE STRING "" FORCE)
+    set(EmbeddedPython_EXECUTABLE "${EmbeddedPython_ROOT_DIR}/python3" CACHE STRING "" FORCE)
 endif()
+
+# See docstring of `embedded_python_generate_home_file()`. It's up to the user to pick if they
+# want to point the `-core` package (no `pip` package) or the full embedded environment.
+embedded_python_generate_home_file(".embedded_python.home" "${EmbeddedPython_ROOT_DIR}")

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -64,8 +64,11 @@ class TestEmbeddedPython(ConanFile):
         cmake = CMake(self)
         cmake.configure(
             variables={
+                # To test that we find the correct prefix for `Python_EXECUTABLE`
                 "EXPECTED_PYTHON_CORE_PATH": self._core_package_path.as_posix(),
                 "EXPECTED_PYTHON_PATH": self._package_path.as_posix(),
+                # We specify the wrong exe here (system Python) to test that we do ignore it
+                "Python_EXECUTABLE": sys.executable,
             }
         )
         cmake.build()


### PR DESCRIPTION
Recent versions of CLion and some VScode extensions have started implicitly passing `-DPython_EXECUTABLE=<system_python>` when configuring CMake. This ends up overriding `find_package(Python)` with bad results. See the first commit, changelog entry, and code comments for more details on the issue and fix.

While we're here, this PR also attempts to provide an alternative to the clumsy `embedded_python_tools.symlink_import()`. See the second commit for the details.